### PR TITLE
fix: add frontmatter "description" property back

### DIFF
--- a/src/pages/posts/2024-年末省思.md
+++ b/src/pages/posts/2024-年末省思.md
@@ -1,7 +1,8 @@
 ---
 layout: ../../layouts/MarkdownPostLayout.astro
 title: '2024 年末省思'
-pubDate: 2024-12-178
+pubDate: 2024-12-18
+description: '2024 年做了什麼，學到了什麼，以及對 2025 年的目標和展望'
 image:
   url: 'https://i.pinimg.com/736x/a0/9e/37/a09e37636e1819d589d6d9f0e60174ea.jpg'
   source: 'https://www.pinterest.com/pin/425238389808445525/'


### PR DESCRIPTION
## Story/Why
Deploy Failed
https://app.netlify.com/sites/arakang/deploys/676292ffdf94cb000842c0a2

![image](https://github.com/user-attachments/assets/6133f2c9-d30f-4d44-8fb5-74b60ac44b51)

## What has been done
拿錯誤訊息搜尋後找到這篇文章 [Fix astro RSS error which says that file has invalid or missing frontmatter.](https://awsm.page/astro/rss-frontmatter-error-markdown/)
發現是因為誤刪 frontmatter 的必要變數之一"description"，所以噴錯

## Additonal Note
GPT 說法：
在 Astro 中，使用 @astrojs/rss 套件生成 RSS feed 時，會檢查每個 Markdown 檔案的 frontmatter，確保必要的屬性（如 title、pubDate）存在，因為 RSS 格式要求每個項目需要包含這些基本資訊。
如果缺少了這些必要屬性，RSS 生成器就無法構建有效的 RSS feed，這也是為什麼它會報錯的原因。
（先記錄下來但持保留意見，之後追一下再回頭紀錄）